### PR TITLE
Update pandoc version to 3.1.2 min required by M architecture

### DIFF
--- a/add-lesson.sh
+++ b/add-lesson.sh
@@ -18,7 +18,7 @@ if [[ ${FILE} != "empty" && ! -e "${FILE}.R" ]]; then
   echo '#' >> "${FILE}.R"
   echo '# library("fs")' >> "${FILE}.R"
   echo '# library("xml2")' >> "${FILE}.R"
-  echo '# pandoc::pandoc_activate("2.19.2")' >> "${FILE}.R"
+  echo '# pandoc::pandoc_activate("3.1.2")' >> "${FILE}.R"
   echo '# source("functions.R")' >> "${FILE}.R"
   echo "# old        <- '${FILE}'" >> "${FILE}.R"
   echo "# new        <- 'sandpaper/${FILE}'" >> "${FILE}.R"

--- a/carpentries-incubator/good-enough-practices.R
+++ b/carpentries-incubator/good-enough-practices.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'carpentries-incubator/good-enough-practices'
 # new        <- 'sandpaper/carpentries-incubator/good-enough-practices'

--- a/carpentries/instructor-training-bonus-modules.R
+++ b/carpentries/instructor-training-bonus-modules.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'carpentries/instructor-training-bonus-modules'
 # new        <- 'sandpaper/carpentries/instructor-training-bonus-modules'

--- a/datacarpentry/astronomy-python.R
+++ b/datacarpentry/astronomy-python.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/astronomy-python'
 # new        <- 'sandpaper/datacarpentry/astronomy-python'

--- a/datacarpentry/cloud-genomics.R
+++ b/datacarpentry/cloud-genomics.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/cloud-genomics'
 # new        <- 'sandpaper/datacarpentry/cloud-genomics'

--- a/datacarpentry/ecology-workshop.R
+++ b/datacarpentry/ecology-workshop.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/ecology-workshop'
 # new        <- 'sandpaper/datacarpentry/ecology-workshop'

--- a/datacarpentry/genomics-r-intro.R
+++ b/datacarpentry/genomics-r-intro.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/genomics-r-intro'
 # new        <- 'sandpaper/datacarpentry/genomics-r-intro'

--- a/datacarpentry/genomics-workshop.R
+++ b/datacarpentry/genomics-workshop.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/genomics-workshop'
 # new        <- 'sandpaper/datacarpentry/genomics-workshop'

--- a/datacarpentry/geospatial-workshop.R
+++ b/datacarpentry/geospatial-workshop.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/geospatial-workshop'
 # new        <- 'sandpaper/datacarpentry/geospatial-workshop'

--- a/datacarpentry/image-processing.R
+++ b/datacarpentry/image-processing.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/image-processing'
 # new        <- 'sandpaper/datacarpentry/image-processing'

--- a/datacarpentry/openrefine-socialsci.R
+++ b/datacarpentry/openrefine-socialsci.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/openrefine-socialsci'
 # new        <- 'sandpaper/datacarpentry/openrefine-socialsci'

--- a/datacarpentry/organization-genomics.R
+++ b/datacarpentry/organization-genomics.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/organization-genomics'
 # new        <- 'sandpaper/datacarpentry/organization-genomics'

--- a/datacarpentry/organization-geospatial.R
+++ b/datacarpentry/organization-geospatial.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/organization-geospatial'
 # new        <- 'sandpaper/datacarpentry/organization-geospatial'

--- a/datacarpentry/python-ecology-lesson.R
+++ b/datacarpentry/python-ecology-lesson.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/python-ecology-lesson'
 # new        <- 'sandpaper/datacarpentry/python-ecology-lesson'

--- a/datacarpentry/python-socialsci.R
+++ b/datacarpentry/python-socialsci.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/python-socialsci'
 # new        <- 'sandpaper/datacarpentry/python-socialsci'

--- a/datacarpentry/r-intro-geospatial.R
+++ b/datacarpentry/r-intro-geospatial.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/r-intro-geospatial'
 # new        <- 'sandpaper/datacarpentry/r-intro-geospatial'

--- a/datacarpentry/shell-genomics.R
+++ b/datacarpentry/shell-genomics.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/shell-genomics'
 # new        <- 'sandpaper/datacarpentry/shell-genomics'

--- a/datacarpentry/socialsci-workshop.R
+++ b/datacarpentry/socialsci-workshop.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/socialsci-workshop'
 # new        <- 'sandpaper/datacarpentry/socialsci-workshop'

--- a/datacarpentry/spreadsheet-ecology-lesson.R
+++ b/datacarpentry/spreadsheet-ecology-lesson.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/spreadsheet-ecology-lesson'
 # new        <- 'sandpaper/datacarpentry/spreadsheet-ecology-lesson'

--- a/datacarpentry/spreadsheets-socialsci.R
+++ b/datacarpentry/spreadsheets-socialsci.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/spreadsheets-socialsci'
 # new        <- 'sandpaper/datacarpentry/spreadsheets-socialsci'

--- a/datacarpentry/sql-ecology-lesson.R
+++ b/datacarpentry/sql-ecology-lesson.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/sql-ecology-lesson'
 # new        <- 'sandpaper/datacarpentry/sql-ecology-lesson'

--- a/datacarpentry/sql-socialsci.R
+++ b/datacarpentry/sql-socialsci.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/sql-socialsci'
 # new        <- 'sandpaper/datacarpentry/sql-socialsci'

--- a/datacarpentry/wrangling-genomics.R
+++ b/datacarpentry/wrangling-genomics.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'datacarpentry/wrangling-genomics'
 # new        <- 'sandpaper/datacarpentry/wrangling-genomics'

--- a/establish-template.R
+++ b/establish-template.R
@@ -48,10 +48,10 @@ file_delete(to("README.md"))
 dir_delete(to(".git"))
 dir_delete(to("renv/profiles/lesson-requirements/renv"))
 cli::cli_alert_info("Provisioning pandoc")
-if (!pandoc_is_installed("2.19.2")) {
-  pandoc_install("2.19.2")
+if (!pandoc_is_installed("3.1.2")) {
+  pandoc_install("3.1.2")
 }
-pandoc_activate("2.19.2")
+pandoc_activate("3.1.2")
 for (line in pandoc_run("--version")) {
   cli::cli_text(cli::col_cyan("\t{.emph {line}}"))
 }

--- a/librarycarpentry/lc-data-intro-archives.R
+++ b/librarycarpentry/lc-data-intro-archives.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-data-intro-archives'
 # new        <- 'sandpaper/librarycarpentry/lc-data-intro-archives'

--- a/librarycarpentry/lc-data-intro.R
+++ b/librarycarpentry/lc-data-intro.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-data-intro'
 # new        <- 'sandpaper/librarycarpentry/lc-data-intro'

--- a/librarycarpentry/lc-dig-pres.R
+++ b/librarycarpentry/lc-dig-pres.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-dig-pres'
 # new        <- 'sandpaper/librarycarpentry/lc-dig-pres'

--- a/librarycarpentry/lc-git.R
+++ b/librarycarpentry/lc-git.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-git'
 # new        <- 'sandpaper/librarycarpentry/lc-git'

--- a/librarycarpentry/lc-marcedit.R
+++ b/librarycarpentry/lc-marcedit.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-marcedit'
 # new        <- 'sandpaper/librarycarpentry/lc-marcedit'

--- a/librarycarpentry/lc-open-refine.R
+++ b/librarycarpentry/lc-open-refine.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-open-refine'
 # new        <- 'sandpaper/librarycarpentry/lc-open-refine'

--- a/librarycarpentry/lc-overview.R
+++ b/librarycarpentry/lc-overview.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-overview'
 # new        <- 'sandpaper/librarycarpentry/lc-overview'

--- a/librarycarpentry/lc-python-intro.R
+++ b/librarycarpentry/lc-python-intro.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-python-intro'
 # new        <- 'sandpaper/librarycarpentry/lc-python-intro'

--- a/librarycarpentry/lc-shell.R
+++ b/librarycarpentry/lc-shell.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-shell'
 # new        <- 'sandpaper/librarycarpentry/lc-shell'

--- a/librarycarpentry/lc-spreadsheets.R
+++ b/librarycarpentry/lc-spreadsheets.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-spreadsheets'
 # new        <- 'sandpaper/librarycarpentry/lc-spreadsheets'

--- a/librarycarpentry/lc-sql.R
+++ b/librarycarpentry/lc-sql.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-sql'
 # new        <- 'sandpaper/librarycarpentry/lc-sql'

--- a/librarycarpentry/lc-wikidata.R
+++ b/librarycarpentry/lc-wikidata.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'librarycarpentry/lc-wikidata'
 # new        <- 'sandpaper/librarycarpentry/lc-wikidata'

--- a/swcarpentry/git-novice-es.R
+++ b/swcarpentry/git-novice-es.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/git-novice-es'
 # new        <- 'sandpaper/swcarpentry/git-novice-es'

--- a/swcarpentry/git-novice.R
+++ b/swcarpentry/git-novice.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/git-novice'
 # new        <- 'sandpaper/swcarpentry/git-novice'

--- a/swcarpentry/hg-novice.R
+++ b/swcarpentry/hg-novice.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/hg-novice'
 # new        <- 'sandpaper/swcarpentry/hg-novice'

--- a/swcarpentry/hpc-novice.R
+++ b/swcarpentry/hpc-novice.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/hpc-novice'
 # new        <- 'sandpaper/swcarpentry/hpc-novice'

--- a/swcarpentry/make-novice.R
+++ b/swcarpentry/make-novice.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/make-novice'
 # new        <- 'sandpaper/swcarpentry/make-novice'

--- a/swcarpentry/matlab-novice-inflammation.R
+++ b/swcarpentry/matlab-novice-inflammation.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/matlab-novice-inflammation'
 # new        <- 'sandpaper/swcarpentry/matlab-novice-inflammation'

--- a/swcarpentry/python-novice-gapminder.R
+++ b/swcarpentry/python-novice-gapminder.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/python-novice-gapminder'
 # new        <- 'sandpaper/swcarpentry/python-novice-gapminder'

--- a/swcarpentry/python-novice-inflammation.R
+++ b/swcarpentry/python-novice-inflammation.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/python-novice-inflammation'
 # new        <- 'sandpaper/swcarpentry/python-novice-inflammation'

--- a/swcarpentry/r-novice-gapminder-es.R
+++ b/swcarpentry/r-novice-gapminder-es.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/r-novice-gapminder-es'
 # new        <- 'sandpaper/swcarpentry/r-novice-gapminder-es'

--- a/swcarpentry/r-novice-gapminder.R
+++ b/swcarpentry/r-novice-gapminder.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/r-novice-gapminder'
 # new        <- 'sandpaper/swcarpentry/r-novice-gapminder'

--- a/swcarpentry/r-novice-inflammation.R
+++ b/swcarpentry/r-novice-inflammation.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/r-novice-inflammation'
 # new        <- 'sandpaper/swcarpentry/r-novice-inflammation'

--- a/swcarpentry/shell-novice-es.R
+++ b/swcarpentry/shell-novice-es.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/shell-novice-es'
 # new        <- 'sandpaper/swcarpentry/shell-novice-es'

--- a/swcarpentry/shell-novice.R
+++ b/swcarpentry/shell-novice.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/shell-novice'
 # new        <- 'sandpaper/swcarpentry/shell-novice'

--- a/swcarpentry/sql-novice-survey.R
+++ b/swcarpentry/sql-novice-survey.R
@@ -12,7 +12,7 @@
 #
 # library("fs")
 # library("xml2")
-# pandoc::pandoc_activate("2.19.2")
+# pandoc::pandoc_activate("3.1.2")
 # source("functions.R")
 # old        <- 'swcarpentry/sql-novice-survey'
 # new        <- 'sandpaper/swcarpentry/sql-novice-survey'

--- a/transform-lesson.R
+++ b/transform-lesson.R
@@ -40,7 +40,7 @@ Usage:
 library("fs")
 library("pandoc")
 library("docopt")
-pandoc_activate("2.19.2")
+pandoc_activate("3.1.2")
 options(cli.width = 160)
 
 arguments <- docopt(doc, version = "Stunning Barnacle 2021-11", help = TRUE)


### PR DESCRIPTION
The minimum Pandoc version that runs on Mac M processors is 3.1.2.  After this modification, I as able to successfully convert  Python for the Humanities lesson without any apparent issues.  Pushed to my own fork for testing: https://quist00.github.io/python-humanities-lesson/
