### PR TITLE
check whether workbench-beta-phase.yml exists before deleting

### DIFF
--- a/final-transition.R
+++ b/final-transition.R
@@ -89,9 +89,10 @@ if (dir_exists(new)) {
     writeLines(bad_hashes[1], invalidfile)
   }
 }
-
-cli::cli_alert_info("removing workbench beta phase yaml (inserted by template)")
-fs::file_delete(fs::path(new, ".github", "workflows", "workbench-beta-phase.yml"))
+if (fs::file_exists(fs::path(new, ".github", "workflows", "workbench-beta-phase.yml"))) {
+  cli::cli_alert_info("removing workbench beta phase yaml (inserted by template)")
+  fs::file_delete(fs::path(new, ".github", "workflows", "workbench-beta-phase.yml"))
+}
 set_config(c(
   "source" = paste0("https://github.com/", repo),
   "url" = url


### PR DESCRIPTION
Community members have been running into a problem where the workbench-beta-phase.yml workflow does not exist in their transitioned lesson, causing `final-transition.R` to fail very close to the end. It results in a Workbench lesson that _looks_ transitioned at first glance, but that includes a few problems due to the last handful of lines not running in that script.

This change introduces a check for whether that workflow file exists before trying to delete it, which circumvents the problem.