### PR TITLE
⬆️ Upgrade renv lock dependencies

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -723,7 +723,7 @@
       "Package": "ragg",
       "Version": "1.3.2",
       "Source": "Repository",
-      "Repository": "https://carpentries.r-universe.dev",
+      "Repository": "CRAN",
       "Requirements": [
         "systemfonts",
         "textshaping"
@@ -803,7 +803,7 @@
     },
     "sandpaper": {
       "Package": "sandpaper",
-      "Version": "0.16.6",
+      "Version": "0.16.9",
       "Source": "Repository",
       "Repository": "https://carpentries.r-universe.dev",
       "Requirements": [
@@ -832,7 +832,7 @@
         "withr",
         "yaml"
       ],
-      "Hash": "766498aa0c35795e431003acb08f28c6"
+      "Hash": "ead7d47bf156dac02e7c441cbed4b9f3"
     },
     "sass": {
       "Package": "sass",


### PR DESCRIPTION
The version of sandpaper referenced in the `renv.lock` file no longer exists in the Carpentries r-universe repo (something I feel is a broader problem that should be addressed, but outside of the current scope). The PR updates the lock file to point to the currently available version.
